### PR TITLE
Develop

### DIFF
--- a/chardev.c
+++ b/chardev.c
@@ -49,7 +49,7 @@ static ssize_t device_write(struct file *file,
   return i;
 }
 
-static ssize_t device_read(struct inode *inode,
+static ssize_t device_read(stuct inode *inode,
 			   struct file *file,
 			   char *buffer,
  			   size_t length,
@@ -99,16 +99,12 @@ int device_ioctl(struct inode *inode,
 /***************** module declarations **********************/
 
 struct file_operations fops = {
-  NULL,   /* seek */
-  device_read, 
-  device_write,
-  NULL,   /* readdir */
-  NULL,   /* select */
-  device_ioctl,   /* ioctl */
-  NULL,   /* mmap */
-  device_open,
-  NULL,  /* flush */
-  device_release  /* a.k.a. close */
+  .owner = THIS_MODULE,
+  .read = device_read,
+  .write = device_write,
+  .ioctl = device_ioctl,
+  .open = device_open,
+  .release = device_release
 };
 
 /* Initialize the module - Register the character device */

--- a/chardev.c
+++ b/chardev.c
@@ -83,7 +83,7 @@ static ssize_t device_read(struct file *file,
   int bytes_read = 0;
   printk("device_read(%p,%p,%zu)\n", file, buffer, length);
   bytes_read = get_msg(buffer, length);
-  printk ("Read %d bytes, %zu left\n", bytes_read, length);
+  printk ("Read %d bytes, %zu left\n", bytes_read, length - bytes_read);
   return bytes_read;
 }
 
@@ -159,7 +159,7 @@ int init_module()
   /* Register the character device (atleast try) */
   ret_val = module_register_chrdev(MAJOR_NUM, 
                                  DEVICE_NAME,
-                                 &Fops);
+                                 &fops);
 
   /* Negative values signify an error */
   if (ret_val < 0) {

--- a/chardev.c
+++ b/chardev.c
@@ -24,8 +24,6 @@ static int device_open(struct inode *inode,
   atomic_inc(&deviceOpen);
   messagePtr = message;
 
-  MOD_INC_USE_COUNT;
-
   return 0;
 }
 
@@ -34,8 +32,6 @@ static int device_release(struct inde *inode,
   printk("device_release(%p, %p)\n", inode, file);
 
   atomic_dec(&deviceOpen);
-
-  MOD_DEC_USE_COUNT;
 
   return 0;
 }

--- a/chardev.c
+++ b/chardev.c
@@ -41,7 +41,7 @@ static ssize_t device_write(struct file *file,
                             size_t length,
                             loff_t *offset) {
   int i;
-  printk("device write(%p, %s, %d)", file, buffer, length);
+  printk("device write(%p, %s, %zu)", file, buffer, length);
   for(i = 0; i < length && BUF_LEN; i++) {
     get_user(message[i], buffer+i);  
   }
@@ -55,7 +55,7 @@ static ssize_t device_read(struct inode *inode,
  			   size_t length,
 			   loff_t *offset) {
   int bytes_read = 0;
-  printk("device_read(%p,%p,%d)\n", file, buffer, length);
+  printk("device_read(%p,%p,%zu)\n", file, buffer, length);
   if(*messagePtr == 0) {
     return 0;
   }
@@ -65,7 +65,7 @@ static ssize_t device_read(struct inode *inode,
     length--;
     bytes_read++;
   }
-  printk ("Read %d bytes, %d left\n", bytes_read, length);
+  printk ("Read %d bytes, %zu left\n", bytes_read, length);
   return bytes_read;
 }
 

--- a/chardev.c
+++ b/chardev.c
@@ -27,7 +27,7 @@ static int device_open(struct inode *inode,
   return 0;
 }
 
-static int device_release(struct inde *inode,
+static int device_release(struct inode *inode,
                           struct file *file) {
   printk("device_release(%p, %p)\n", inode, file);
 

--- a/chardev.c
+++ b/chardev.c
@@ -9,7 +9,7 @@
 
 #define BUF_LEN 80
 
-static int deviceOpen = 0;
+static atomic_t deviceOpen = ATOMIC_INIT(0);
 static char message[BUF_LEN];
 static char *messagePtr;
 
@@ -17,11 +17,11 @@ static int device_open(struct inode *inode,
                        struct file *file) {
   printk("device_open(%p)\n", file);
 
-  if(deviceOpen) {
+  if(atomic_read(&deviceOpen)) {
     return -EBUSY;
   }
 
-  deviceOpen++;
+  atomic_inc(&deviceOpen);
   messagePtr = message;
 
   MOD_INC_USE_COUNT;
@@ -33,7 +33,7 @@ static int device_release(struct inde *inode,
                           struct file *file) {
   printk("device_release(%p, %p)\n", inode, file);
 
-  deviceOpen--;
+  atomic_dec(&deviceOpen);
 
   MOD_DEC_USE_COUNT;
 

--- a/chardev.c
+++ b/chardev.c
@@ -49,8 +49,7 @@ static ssize_t device_write(struct file *file,
   return i;
 }
 
-static ssize_t device_read(stuct inode *inode,
-			   struct file *file,
+static ssize_t device_read(struct file *file,
 			   char *buffer,
  			   size_t length,
 			   loff_t *offset) {


### PR DESCRIPTION
Small fixes and workarounds. Still cannot be compiled (need to change the device creation logic and create a few absent routines).
Set/get functions should protect the data with a mutex or RW lock to prevent data races.